### PR TITLE
Fixed invalid TreatMissingData parameter in alarm resource.

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -51,7 +51,7 @@ Resources:
       Period: 3600
       Statistic: Maximum
       Threshold: .1
-      TreatMissingData: Missing
+      TreatMissingData: missing
 
   SG:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
Supported values for TreatMissingData parameter are [breaching, notBreaching, ignore, missing]. "Missing" != "missing"